### PR TITLE
replace all backslashes(\) with forward slashes (/) in curl statements

### DIFF
--- a/lib/webdav_sync.js
+++ b/lib/webdav_sync.js
@@ -53,7 +53,7 @@ module.exports = function(options) {
       return;
     }
     processed.push("w" + path + stats.mtime);
-    rel_path = path.replace(options.local_base, "");
+    rel_path = path.replace(options.local_base, "").replace("\\","/");
     destination = options.remote_base + rel_path;
     if (ignoreFile(rel_path)) {
       return;
@@ -98,7 +98,7 @@ module.exports = function(options) {
       return;
     }
     processed.push("d" + path + stats.mtime);
-    rel_path = path.replace(options.local_base, "");
+    rel_path = path.replace(options.local_base, "").replace("\\","/");
     destination = options.remote_base + rel_path;
     if (ignoreFile(rel_path)) {
       return;


### PR DESCRIPTION
resolves bug when creating folders and files. curl statement was using \ instead of /
