### PR TITLE
fix ignoreFile problem in the new version node.js

### DIFF
--- a/lib/webdav_sync.js
+++ b/lib/webdav_sync.js
@@ -110,7 +110,10 @@ module.exports = function(options) {
     }
   };
   ignoreFile = function(path) {
-    return __indexOf.call(options.ignored, path) >= 0;
+    var ignoreList = [].concat(options.ignored);
+    for (var index in ignoreList) {
+      if (path.indexOf(ignoreList[index]) >= 0) return true;
+    }
   };
   return {
     start: function() {


### PR DESCRIPTION
The ignore file is not working in node.js 0.10.22, just use a simple way to fix that.
