### PR TITLE
updated to watch 0.17.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "watch": "0.5.x",
+    "watch": "0.17.1",
     "colors": "0.6.x",
     "optimist": "0.3.x",
     "pkginfo": "0.2.x"


### PR DESCRIPTION
After using the webdav-sync for approx. three month every weekday for application development in Adobe Experience Manager (6.1), it suddenly stopped working. After starting the webdav-sync in three out of four tries it immediately goes back to the commandline after the connection test, instead of watching for file changes. I could not track down what was the cause of the problem, but updating from watch 0.5.x to the recent version of watch 0.17.1 fixes this issue for me.
