### PR TITLE
Base path missing from remove action

### DIFF
--- a/lib/webdav_sync.js
+++ b/lib/webdav_sync.js
@@ -178,7 +178,8 @@ module.exports = function (options) {
 
     processed["d" + path + stats.mtime]=currLine;
 
-    rel_path = path.replace(options.local_base, "");
+    rel_path = normalize(url.parse(options.remote_base).path +
+                         path.replace(options.local_base, ""));
     destination = url.resolve(options.remote_base, rel_path);
     if (ignoreFile(rel_path)) {
       return;


### PR DESCRIPTION
## Before
- Delete file in `/path/to/my/file.js`

I get:

```
● [removed] /file.js
```
## After
- Delete file in `/path/to/my/file.js`

I get:

```
● [removed] /path/to/my/file.js
```
